### PR TITLE
NumberToggle function fixed

### DIFF
--- a/.vimrc
+++ b/.vimrc
@@ -101,8 +101,10 @@ set relativenumber
 function! NumberToggle()
   if(&relativenumber == 1)
     set number
+    set norelativenumber
   else
     set relativenumber
+    set nonumber
   endif
 endfunc
 


### PR DESCRIPTION
NumberToggle used to work only once. The variables `number` and and `relativenumber` need to be unset for switching between line number display modes.
